### PR TITLE
Fix MultiRecipeMap localize on TOP

### DIFF
--- a/src/main/java/gregtech/integration/theoneprobe/provider/MultiRecipeMapInfoProvider.java
+++ b/src/main/java/gregtech/integration/theoneprobe/provider/MultiRecipeMapInfoProvider.java
@@ -35,7 +35,7 @@ public class MultiRecipeMapInfoProvider extends CapabilityInfoProvider<IMultiple
             if (recipeMap.equals(iMultipleRecipeMaps.getCurrentRecipeMap())) {
                 iProbeInfo.text("   " + TextStyleClass.INFOIMP + "{*recipemap." + recipeMap.getUnlocalizedName() + ".name*} {*<*}");
             } else {
-                iProbeInfo.text("   " + TextStyleClass.LABEL + recipeMap.getLocalizedName());
+                iProbeInfo.text("   " + TextStyleClass.LABEL + "{*recipemap." + recipeMap.getUnlocalizedName() + ".name*}");
             }
         }
     }


### PR DESCRIPTION
## What
複数のRecipeMapを持つ機械(GCYMのマルチブロック)のTOP表示において、非選択のレシピのローカライズがサーバー側で行われているバグの修正。

## Outcome
MultiRecipeMapInfoProvider.addProbeInfo()内でgetLocalizedNameの使用をやめ、getUnlocalizedNameを使うようにした。
